### PR TITLE
Added a day check for displaying current and next events

### DIFF
--- a/app/src/main/java/town/amrita/timetable/widget/TimetableAppWidget.kt
+++ b/app/src/main/java/town/amrita/timetable/widget/TimetableAppWidget.kt
@@ -252,7 +252,7 @@ fun TitleBar(day: DayOfWeek, locked: Boolean, current: String? = null, next: Str
         )
       }
 
-      if (isBeeg && (current != null || next != null)) {
+      if (isBeeg && (current != null || next != null) && (day == TODAY)) {
         val currentNextString = when {
           current != null && next != null -> "Now $current, next $next"
           current != null -> "Now $current"


### PR DESCRIPTION
Just as a condition in the 145th line
day == TODAY
was added as another condition in the 255th line
to avoid the confusion from the side of the user that is due to displaying "Now $current, next $next" even when the set day is not the same as the day of which the timetable is being displayed